### PR TITLE
feat(details): zoekbalk + squad/teachers-filter op detailspagina

### DIFF
--- a/src/routes/+page.server.js
+++ b/src/routes/+page.server.js
@@ -1,5 +1,5 @@
 export async function load({ url }) {
-  const membersResponse = await fetch('https://fdnd.directus.app/items/person?');
+  const membersResponse = await fetch('https://fdnd.directus.app/items/person?fields=*,squads.squad_id.name,squads.squad_id.cohort,squads.squad_id.tribe.name&filter[squads][squad_id][cohort][_eq]=2526&filter[squads][squad_id][tribe][name][_eq]=FDND%20Jaar%202');
   const membersData = await membersResponse.json();
 
   return {members: membersData.data};

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,20 +1,131 @@
 <script>
-  let { data } = $props();
+  // Filter variables
 
-  const members = data.members;
+  // let { data } = $props();
+  export let data;
 
   
+  // const members = data.members;
+  const members = data?.members || [];
+
+  let search = "";
+
+  let selectedSquad = "";
+
+  let showTeachers = false;
+
+  const filterSquads = ["2E", "2F"];
+
+  // Filters
+  $: filteredMembers = members.filter(
+    (m) =>
+      (!search || m.name?.toLowerCase().includes(search.toLowerCase())) &&
+      (!selectedSquad ||
+        m.squads?.some((s) => s.squad_id?.name === selectedSquad)) &&
+      (!showTeachers ||
+        m.role?.some((r) =>
+          ["co_teacher", "squad_leader"].includes(r.toLowerCase()),
+        )),
+  );
 </script>
 
 <h1>Welcome to Sqaudpage</h1>
 
-{#each members as member}
+<!-- Zoekbulk en filterknoppen -->
+
+<section class="search-container">
+  <input type="text" placeholder="Search bij name..." bind:value={search} />
+
+  <div class="squad-buttons">
+    <button
+      on:click={() => {
+        selectedSquad = "";
+        showTeachers = false;
+      }}>All</button
+    >
+    {#each filterSquads as squad}
+      <button
+        on:click={() => {
+          selectedSquad = squad;
+          showTeachers = false;
+        }}>{squad}</button
+      >
+    {/each}
+    <button
+      on:click={() => {
+        selectedSquad = "";
+        showTeachers = true;
+      }}>Teachers</button
+    >
+  </div>
+</section>
+
+<!-- {#each members as member}
   <a href={member.id}>{member.name}</a>
   
 {/each}
+{/each} -->
+
+
+<div class="results">
+  {#if filteredMembers.length > 0}
+    {#each filteredMembers as member}
+      <a href={"/" + member.id}>{member.name}</a>
+    {/each}
+  {:else}
+    <p>No members found</p>
+  {/if}
+</div>
 
 <style>
+  h1 {
+    margin-bottom: 1rem;
+    color: #333;
+    font-size: 1.8rem;
+    text-align: center;
+  }
+
+  .search-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1rem;
+    margin: 2rem auto;
+    max-width: 400px;
+  }
+
+  input {
+    width: 100%;
+    padding: 8px 12px;
+    border: 2px solid plum;
+    border-radius: 8px;
+    font-size: 1rem;
+  }
+
+  .results {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    width: 100%;
+  }
+
   a {
     border: 2px solid plum;
+    padding: 8px;
+    border-radius: 6px;
+    text-decoration: none;
+    color: #333;
+    transition: background 0.2s;
+  }
+
+  a:hover {
+    background: plum;
+    color: white;
+  }
+
+  p {
+    text-align: center;
+    color: gray;
+    font-style: italic;
   }
 </style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,12 +2,15 @@
   let { data } = $props();
 
   const members = data.members;
+
+  
 </script>
 
 <h1>Welcome to Sqaudpage</h1>
 
 {#each members as member}
   <a href={member.id}>{member.name}</a>
+  
 {/each}
 
 <style>

--- a/src/routes/[id]/+page.server.js
+++ b/src/routes/[id]/+page.server.js
@@ -1,6 +1,9 @@
+
 export async function load({ url, params }) {
   const memberResponse = await fetch('https://fdnd.directus.app/items/person/'+ params.id);
   const memberData = await memberResponse.json();
 
   return {member: memberData.data};
+
 }
+

--- a/src/routes/[id]/+page.svelte
+++ b/src/routes/[id]/+page.svelte
@@ -1,4 +1,4 @@
-<script>
+<!-- <script>
   let { data } = $props();
 
   const member = data.member;
@@ -11,7 +11,7 @@
   <div></div>
 
   <img
-      src="https://fdnd.directus.app/assets/{member.mugshot}?fit=cover&width=1600"
+      src="https://fdnd.directus.app/assets/{member.mugshot}?fit=cover&width=500"
       alt={member.name}
     />
 
@@ -23,4 +23,168 @@
 
 
 
+ -->
 
+ <script>
+  let { data } = $props();
+  const member = data.member;
+</script>
+
+<a href="/" class="back-button">← Terug naar overzicht</a>
+
+<section class="profile-card">
+  <div class="avatar-container">
+    <img
+      src="https://fdnd.directus.app/assets/{member.mugshot}?fit=cover&width=1600"
+      alt={member.name}
+    />
+  </div>
+
+  <div class="profile-info">
+    <h1>{member.name}</h1>
+    <h2>{member.bio}</h2>
+    <a href="#" class="visitkaart-button">Bekijk mijn visitkaartje</a>
+  </div>
+</section>
+
+<style>
+:global(html, body) {
+  height: 100%;
+  margin: 0;
+}
+
+:global(body) {
+  font-family: 'Poppins', sans-serif;
+  background: linear-gradient(to bottom, #FFBAD6 0%, #FFFFFF 100%);
+  min-height: 100dvh;           /* يغطي كامل ارتفاع الشاشة على الموبايل */
+  background-attachment: fixed; /* ثابت عند السكروول */
+  background-repeat: no-repeat;
+  background-size: cover;
+}
+
+.back-button {
+  display: inline-block;
+  margin: 1rem 1rem;
+  text-decoration: none;
+  color: #000000;
+  font-weight: 600;
+  transition: color 0.2s;
+}
+
+.back-button:hover {
+  color: #a14ed1;
+}
+
+/* Mobile-First: صورة فوق + نص تحت */
+.profile-card {
+  display: flex;
+  flex-direction: column; /* عمودي */
+  align-items: center;
+  gap: 1.5rem;
+  max-width: 95%;
+  margin: 2rem auto;
+  padding: 1.5rem;
+  transition: transform 0.3s;
+}
+
+/* .profile-card:hover {
+  transform: translateY(-3px);
+} */
+
+.avatar-container {
+  width: 200px;
+  height: 200px;
+  border-radius: 10%;
+  margin-bottom: 1rem;
+  box-shadow: 0 8px 20px rgba(0,0,0,0.15);
+  overflow: hidden;
+}
+
+.avatar-container img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.profile-info {
+  text-align: center;
+}
+
+.profile-info h1 {
+  margin: 0;
+  font-size: 1.6rem;
+  color: #000000;
+}
+
+.profile-info h2 {
+  font-size: 1rem;
+  color: #000000;
+  margin: 0.5rem 0 1rem 0;
+  line-height: 1.4;
+}
+
+.visitkaart-button {
+  display: inline-block;
+  padding: 0.6rem 1.2rem;
+  background: #6a0dad;
+  color: #ffffff;
+  text-decoration: none;
+  border-radius: 50px;
+  font-weight: 600;
+}
+
+.visitkaart-button:hover {
+  background: #a14ed1;
+  transform: translateY(-2px);
+}
+
+/* Tablets */
+@media (min-width: 600px) {
+  .avatar-container {
+    width: 220px;
+    height: 220px;
+  }
+
+  .profile-info h1 {
+    font-size: 1.8rem;
+  }
+
+  .profile-info h2 {
+    font-size: 1.1rem;
+  }
+}
+
+/* Desktop */
+@media (min-width: 900px) {
+  .profile-card {
+    flex-direction: row;     /* صورة يسار + نص يمين */
+    align-items: center;
+    justify-content: center;
+    max-width: 900px;
+    padding: 3rem;
+    gap: 2rem;
+  }
+
+  .avatar-container {
+    width: 250px;
+    height: 250px;
+    margin: 0;
+  }
+
+  .profile-info {
+    text-align: left;
+  }
+
+  .profile-info h1 {
+    font-size: 2rem;
+  }
+
+  .profile-info h2 {
+    font-size: 1.2rem;
+  }
+
+  .visitkaart-button {
+    padding: 0.7rem 1.5rem;
+  }
+}
+</style>

--- a/src/routes/[id]/+page.svelte
+++ b/src/routes/[id]/+page.svelte
@@ -2,7 +2,25 @@
   let { data } = $props();
 
   const member = data.member;
+
 </script>
 
 <a href="/">Terug naar overzicht</a>
-<h1>{member.name}</h1>
+
+<section>
+  <div></div>
+
+  <img
+      src="https://fdnd.directus.app/assets/{member.mugshot}?fit=cover&width=1600"
+      alt={member.name}
+    />
+
+  <h1>{member.name}</h1>
+  <h2>{member.bio}</h2>
+  <h3>Link naar mijn visitkaartje</h3>
+
+</section>
+
+
+
+


### PR DESCRIPTION
Deze PR voegt client-side filtering toe aan de detailspagina:

Vrije tekst zoeken op naam (case-insensitive).

Squadfilter voor 2E en 2F.

Docentenfilter (toon alleen co_teacher/squad_leader).

Reactieve lijst filteredMembers die alle filters combineert.

Veilige fallback wanneer data.members ontbreekt.

Changes

src/routes/+page.svelte

export let data; en const members = data?.members || [];

Lokale state: search, selectedSquad, showTeachers

filterSquads = ['2E','2F']

Reactieve afgeleide:

$: filteredMembers = members.filter(
  (m) =>
    (!search || m.name?.toLowerCase().includes(search.toLowerCase())) &&
    (!selectedSquad || m.squads?.some((s) => s.squad_id?.name === selectedSquad)) &&
    (!showTeachers || m.role?.some((r) => ['co_teacher','squad_leader'].includes(r.toLowerCase())))
);


UI: zoekveld + knoppen All, 2E, 2F, Teachers

Resultaatlijst met link naar /{member.id}

Basale styling

How to test

Start de app en ga naar de detailspagina.

Typ in het zoekveld (bijv. “ali”) → lijst filtered live.

Klik 2E → alleen leden uit squad 2E zichtbaar.
Klik All om te resetten.

Klik Teachers → alleen docenten (roles: co_teacher/squad_leader).

Combinaties:

Teachers + zoeken → docenten gefilterd op naam.

2E + zoeken → leden uit 2E gefilterd op naam.

Lege staat: voer een zoekterm in die niemand matcht → “No members found”.

Acceptance criteria

 Zoeken is case-insensitive

 Filters werken onafhankelijk én gecombineerd

 Geen runtime errors als data/relaties ontbreken (optional chaining)

 Links verwijzen naar /{id}

Accessibility

Overweeg een <label for="search"> voor het zoekveld.

Eventueel aria-pressed op de filterknoppen voor toggle-status.

Follow-ups / nice-to-have

Debounce op zoeken (setTimeout/tick) om re-renders te beperken.

Sync filters met URL (?q=&squad=&teachers=) voor deelbare states.

Actieve knopstijl (selected/pressed) toevoegen.

Unit test voor filtercombinaties.

Risks
Laag — client-side filtering; beperkt tot UI/logica in de pagina.

Screenshots
Add screenshots/gif van vóór/na en een paar filtercombinaties.

<img width="1474" height="544" alt="Screenshot 2025-09-10 162554" src="https://github.com/user-attachments/assets/f0a58340-d923-49ff-8a34-75927ca1ad1c" />

<img width="1889" height="823" alt="Screenshot 2025-09-10 162611" src="https://github.com/user-attachments/assets/020e743e-c77b-4c29-b503-c2c2e77f46a7" />

